### PR TITLE
Improvements and fixes

### DIFF
--- a/example-simple/src/main.cpp
+++ b/example-simple/src/main.cpp
@@ -6,7 +6,8 @@
 //#define OFXCPPSKETCH_CUSTOM_COMPILER "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
 //#define OFXCPPSKETCH_CUSTOM_STD_VERSION " -std=c++17"
 //#define OFXCPPSKETCH_CUSTOM_MAC_SDK "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk"
-//#define OFXCPPSKETCH_CUSTOM_EXTRA_FLAGS " -O0 -target x86_64-apple-macosx10.15-macho -pipe -fexceptions -fvisibility=default -Wno-unused-parameter -Werror=return-type -fPIC -DDEBUG -DGCC_HAS_REGEX"
+//#define OFXCPPSKETCH_CUSTOM_COMPILER_FLAGS " -W" // Disables any warnings
+//#define OFXCPPSKETCH_CUSTOM_LINKER_FLAGS ""
 
 #include "ofxCppSketch.h"
 

--- a/example-simple/src/main.cpp
+++ b/example-simple/src/main.cpp
@@ -3,10 +3,10 @@
 
 // You can set these variables to customise the compiler
 // Be sure to set them before any "ofxCppSketch.cpp"
-#define OFXCPPSKETCH_CUSTOM_COMPILER "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
-#define OFXCPPSKETCH_CUSTOM_STD_VERSION " -std=c++17"
-#define OFXCPPSKETCH_CUSTOM_MAC_SDK "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk"
-#define OFXCPPSKETCH_CUSTOM_EXTRA_FLAGS " -O0 -target x86_64-apple-macosx10.15-macho -pipe -fexceptions -fvisibility=default -Wno-unused-parameter -Werror=return-type -fPIC -DDEBUG -DGCC_HAS_REGEX"
+//#define OFXCPPSKETCH_CUSTOM_COMPILER "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
+//#define OFXCPPSKETCH_CUSTOM_STD_VERSION " -std=c++17"
+//#define OFXCPPSKETCH_CUSTOM_MAC_SDK "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk"
+//#define OFXCPPSKETCH_CUSTOM_EXTRA_FLAGS " -O0 -target x86_64-apple-macosx10.15-macho -pipe -fexceptions -fvisibility=default -Wno-unused-parameter -Werror=return-type -fPIC -DDEBUG -DGCC_HAS_REGEX"
 
 #include "ofxCppSketch.h"
 

--- a/example-simple/src/main.cpp
+++ b/example-simple/src/main.cpp
@@ -1,5 +1,13 @@
 #include "ofMain.h"
 #include "ofApp.h"
+
+// You can set these variables to customise the compiler
+// Be sure to set them before any "ofxCppSketch.cpp"
+#define OFXCPPSKETCH_CUSTOM_COMPILER "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
+#define OFXCPPSKETCH_CUSTOM_STD_VERSION " -std=c++17"
+#define OFXCPPSKETCH_CUSTOM_MAC_SDK "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk"
+#define OFXCPPSKETCH_CUSTOM_EXTRA_FLAGS " -O0 -target x86_64-apple-macosx10.15-macho -pipe -fexceptions -fvisibility=default -Wno-unused-parameter -Werror=return-type -fPIC -DDEBUG -DGCC_HAS_REGEX"
+
 #include "ofxCppSketch.h"
 
 //========================================================================

--- a/example-simple/src/ofApp.cpp
+++ b/example-simple/src/ofApp.cpp
@@ -26,6 +26,11 @@ void ofApp::draw(){
 		//p.draw();
 	}
 	mesh.draw(OF_MESH_POINTS);
+
+	// Uncomment the lines below, save and check your app reloading !
+	//ofSetColor(ofColor::white);
+	//ofFill();
+	//ofDrawCircle(100,100,0,100);
 }
 
 //--------------------------------------------------------------

--- a/src/ReloadableClass.h
+++ b/src/ReloadableClass.h
@@ -109,6 +109,7 @@ public:
 	void precompileHeader(const string &headerToPrecompile) {
 		std::string cmd = getCompilerBaseCmd();
 		cmd += " -x c++-header -stdlib=libc++ "
+			+ extraCompilerFlags
 			+ liveCodeUtils::includeListToCFlags(includePaths)
 			+ " " + headerToPrecompile;
 		printf("Precompiling header `%s`: %s\n", headerToPrecompile.c_str(), cmd.c_str());
@@ -160,6 +161,7 @@ private:
 	string compiler = "";
 	string stdVersion = "";
 	string extraCompilerFlags = "";
+	string extraLinkerFlags = "";
 #ifdef __APPLE__
 	string osxSDK = "";
 #endif
@@ -213,14 +215,14 @@ private:
 		
 		std::string cmd = getCompilerBaseCmd();
 		cmd += " -g -stdlib=libc++" + prefixHeaderFlag + " -Wno-deprecated-declarations -c " + cppFile + " -o " + objFile + " "
-					+ includes;
+					+ includes + extraCompilerFlags;
 		
 		int exitCode = 0;
 		string res =  liveCodeUtils::execute(cmd, &exitCode);
 		
 		//printf("Exit code : %d\n", exitCode);
 		if(exitCode==0) {
-			cmd = getCompilerBaseCmd() + " -dynamiclib -g -undefined dynamic_lookup -o "+dylibPath + " " + objFile;
+			cmd = getCompilerBaseCmd() + " -dynamiclib -g -undefined dynamic_lookup " + extraLinkerFlags + " -o "+dylibPath + " " + objFile;
 			liveCodeUtils::execute(cmd);
 			return dylibPath;
 		} else {
@@ -316,7 +318,6 @@ private:
 			cmd += osxSDK;
 		}
 #endif
-		cmd += extraCompilerFlags;
 
 		return cmd;
 	}
@@ -367,10 +368,15 @@ private:
 #endif
 
 		// EXTRA SETTINGS
-#ifdef OFXCPPSKETCH_CUSTOM_EXTRA_FLAGS
-		extraCompilerFlags = OFXCPPSKETCH_CUSTOM_EXTRA_FLAGS;
+#ifdef OFXCPPSKETCH_CUSTOM_COMPILER_FLAGS
+		extraCompilerFlags = OFXCPPSKETCH_CUSTOM_COMPILER_FLAGS;
 #else
 		extraCompilerFlags = "";
+#endif
+#ifdef OFXCPPSKETCH_CUSTOM_LINKER_FLAGS
+		extraLinkerFlags = OFXCPPSKETCH_CUSTOM_LINKER_FLAGS;
+#else
+		extraLinkerFlags = "";
 #endif
 	}
 };

--- a/src/ReloadableClass.h
+++ b/src/ReloadableClass.h
@@ -111,7 +111,7 @@ public:
 		cmd += " -x c++-header -stdlib=libc++ "
 			+ liveCodeUtils::includeListToCFlags(includePaths)
 			+ " " + headerToPrecompile;
-		printf("Precompiling headers: %s\n", cmd.c_str());
+		printf("Precompiling header `%s`: %s\n", headerToPrecompile.c_str(), cmd.c_str());
 		liveCodeUtils::execute(cmd);
 	}
 #ifdef APPLE

--- a/src/ReloadableClass.h
+++ b/src/ReloadableClass.h
@@ -33,6 +33,11 @@ using namespace std;
 template <class T>
 class ReloadableClass {
 public:
+
+	ReloadableClass(){
+		setDefaults();
+	}
+
 	
 	Dylib dylib;
 	
@@ -102,16 +107,62 @@ public:
 	}
 	
 	void precompileHeader(const string &headerToPrecompile) {
-		
-		string cmd = "g++ -std=c++11 -x c++-header -stdlib=libc++ "
+		std::string cmd = getCompilerBaseCmd();
+		cmd += " -x c++-header -stdlib=libc++ "
 			+ liveCodeUtils::includeListToCFlags(includePaths)
 			+ " " + headerToPrecompile;
 		printf("Precompiling headers: %s\n", cmd.c_str());
 		liveCodeUtils::execute(cmd);
 	}
+#ifdef APPLE
+	void setMacosSdk(string sdkPath){
+		osxSDK = sdkPath;
+	}
+	string getMacosSdk() const {
+		return osxSDK;
+	}
+#endif
+	void setCompiler(string compilerStr){
+		compiler = compilerStr;
+	}
+	string getCompiler() const {
+		return compiler;
+	}
+	void setExtraCompilerFlags(string extraFlags){
+		extraCompilerFlags = " ";
+		extraCompilerFlags += extraFlags;
+	}
+	string getExtraCompilerFlags() const {
+		return extraCompilerFlags;
+	}
+	void setStdVersion(int version){
+		if(version < 11){
+			printf("Invalid STD version : %i ! (minimum=11)", version);
+			return;
+		}
+		stdVersion = " -std=c++";
+		stdVersion += std::to_string(version);
+	}
+	void setStdVersion(std::string version){
+		if(version.find("c++")!=0u){
+			printf("Invalid STD version : %s (it must start with `c++`)", version.c_str());
+			return;
+		}
+		stdVersion = " -std=";
+		stdVersion += version;
+	}
+	string getStdVersionStr() const {
+		return stdVersion;
+	}
 	
 	
 private:
+	string compiler = "";
+	string stdVersion = "";
+	string extraCompilerFlags = "";
+#ifdef __APPLE__
+	string osxSDK = "";
+#endif
 	string lastErrorStr;
 	void recompile() {
 		//printf("Need to recompile %s\n", path.c_str());
@@ -157,10 +208,11 @@ private:
 		
 		string prefixHeaderFlag = "";
 		if(prefixHeader!="") {
-			prefixHeaderFlag = "-include " + prefixHeader + " ";
+			prefixHeaderFlag = " -include " + prefixHeader + " ";
 		}
 		
-		string cmd = "g++ -g -std=c++11 -stdlib=libc++ "+prefixHeaderFlag+" -Wno-deprecated-declarations -c " + cppFile + " -o " + objFile + " "
+		std::string cmd = getCompilerBaseCmd();
+		cmd += " -g -stdlib=libc++" + prefixHeaderFlag + " -Wno-deprecated-declarations -c " + cppFile + " -o " + objFile + " "
 					+ includes;
 		
 		int exitCode = 0;
@@ -168,7 +220,7 @@ private:
 		
 		//printf("Exit code : %d\n", exitCode);
 		if(exitCode==0) {
-			cmd = "g++ -dynamiclib -g -undefined dynamic_lookup -o "+dylibPath + " " + objFile;
+			cmd = getCompilerBaseCmd() + " -dynamiclib -g -undefined dynamic_lookup -o "+dylibPath + " " + objFile;
 			liveCodeUtils::execute(cmd);
 			return dylibPath;
 		} else {
@@ -250,5 +302,75 @@ private:
 		if(File(f).exists()) return f;
 		printf("Error: can't find source file %s\n", file.c_str());
 		return f;
+	}
+
+	std::string getCompilerBaseCmd(){
+		std::string cmd = compiler;
+
+		// Add c++ std version
+		cmd += stdVersion;
+
+#ifdef __APPLE__
+		if(!osxSDK.empty()){
+			cmd += " -isysroot ";
+			cmd += osxSDK;
+		}
+#endif
+		cmd += extraCompilerFlags;
+
+		return cmd;
+	}
+
+	void setDefaults(){
+		// STD VERSION
+		stdVersion = " -std=c++11"; // default
+		// Auto-detect from build settings
+#ifdef __cplusplus
+	#if __cplusplus == 202002L
+		stdVersion = " -std=c++20";
+	#elif __cplusplus == 201703L
+		stdVersion = " -std=c++17";
+	#elif __cplusplus == 201402L
+		stdVersion = " -std=c++14";
+	#endif
+#endif
+		// Use custom one ?
+#ifdef OFXCPPSKETCH_CUSTOM_STD_VERSION
+		stdVersion = OFXCPPSKETCH_CUSTOM_STD_VERSION;
+#endif
+
+		// COMPILER
+		compiler = OFXCPPSKETCH_DEFAULT_COMPILER;
+#ifdef __APPLE__
+		// Use Xcode compiler
+		std::string tmpCompiler = liveCodeUtils::macGetCompilerPath();
+		if(!tmpCompiler.empty()){
+			compiler = tmpCompiler;
+		}
+#endif
+		// Use custom one ?
+#ifdef OFXCPPSKETCH_CUSTOM_COMPILER
+		compiler = OFXCPPSKETCH_CUSTOM_COMPILER;
+#endif
+
+		// APPLE SDK
+#ifdef __APPLE__
+		// Grab compiler from xcode settings
+		std::string sysRootSDK = liveCodeUtils::macGetSysRoot();
+		if(!sysRootSDK.empty()){
+			osxSDK = sysRootSDK;
+		}
+#endif
+		// Use custom one ?
+#ifdef OFXCPPSKETCH_CUSTOM_MAC_SDK
+		osxSDK = OFXCPPSKETCH_CUSTOM_MAC_SDK;
+#endif
+
+		// EXTRA SETTINGS
+#ifdef OFXCPPSKETCH_CUSTOM_EXTRA_FLAGS
+		extraCompilerFlags = OFXCPPSKETCH_CUSTOM_EXTRA_FLAGS;
+#else
+		extraCompilerFlags = "";
+#endif
 	}
 };

--- a/src/liveCodeUtils.cpp
+++ b/src/liveCodeUtils.cpp
@@ -238,7 +238,7 @@ bool File::isDirectory() const {
 	
 	// Attempt to get the file attributes 
 	if(stat(path.c_str(),&stFileInfo)!=0) {
-		printf("File not found\n");
+		printf("File not found: %s\n", path.c_str());
 		return false;
 	}
 	return (stFileInfo.st_mode & S_IFMT) == S_IFDIR;
@@ -374,7 +374,7 @@ bool Directory::list() {
 		}
 		closedir(dir);
 	} else {
-		printf("Couldn't open dir\n");
+		printf("Couldn't open dir : %s\n", path.c_str());
 		perror("");
 		return false;
 	}

--- a/src/liveCodeUtils.cpp
+++ b/src/liveCodeUtils.cpp
@@ -17,7 +17,7 @@ void coutPrintf(const char* format, ...){
     std::ostringstream oss;
     va_list args;
     va_start(args, format);
-    char buffer[512];
+    static char buffer[2048];
     vsnprintf(buffer, sizeof(buffer), format, args);
     oss << buffer;
     va_end(args);
@@ -74,8 +74,18 @@ void recursivelyFindAllDirs(Directory curr, vector<Directory> &dirs) {
 	dirs.push_back(curr);
 	curr.list();
 	for(int i = 0; i < curr.size(); i++) {
-		if(curr[i].isDirectory()) {
-			recursivelyFindAllDirs(Directory(curr[i]), dirs);
+		File& next = curr[i];
+		if(next.isDirectory()) {
+			// Ignore some folders (blacklist)
+			if(
+				next.fileName().find(".") == 0			// invisible files (.git, etc.)
+				|| next.fileName()=="obj"				// build folders
+				|| next.fileName().find("example") == 0	// ignore example folders
+				|| next.fileName().find("build-") == 0	// ignore example folders
+			){
+				continue;
+			}
+			recursivelyFindAllDirs(Directory(next), dirs);
 		}
 	}
 }

--- a/src/liveCodeUtils.cpp
+++ b/src/liveCodeUtils.cpp
@@ -12,6 +12,19 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 
+#ifdef OFXCPPSKETCH_USE_COUT
+void coutPrintf(const char* format, ...){
+    std::ostringstream oss;
+    va_list args;
+    va_start(args, format);
+    char buffer[512];
+    vsnprintf(buffer, sizeof(buffer), format, args);
+    oss << buffer;
+    va_end(args);
+    std::cout << oss.str() << std::endl;
+}
+#endif
+
 using namespace std;
 namespace liveCodeUtils {
 	std::chrono::system_clock::time_point startTime;
@@ -23,8 +36,8 @@ void liveCodeUtils::init() {
 
 string liveCodeUtils::execute(string cmd, int *outExitCode) {
 #ifdef __APPLE__
-	printf("Executing %s", cmd.c_str());
-	cmd += " 2>&1";
+	printf("Executing `%s`\n", cmd.c_str());
+	cmd += " 2>&1"; // hide errors
 	FILE* pipe = popen(cmd.c_str(), "r");
 	if (!pipe) return "ERROR";
 	char buffer[128];
@@ -41,6 +54,7 @@ string liveCodeUtils::execute(string cmd, int *outExitCode) {
 	printf("%s\n", result.c_str());
 	return result;
 #else
+	// todo: use ofSystem() here ?
 	return "Error - can't do this";
 #endif
 }
@@ -98,6 +112,50 @@ std::string liveCodeUtils::includeListToCFlags(const std::vector<std::string> &i
 	return str;
 }
 
+// Apple helpers
+#ifdef __APPLE__
+// returns empty string on fail
+std::string liveCodeUtils::macSysCall(std::string cmd){
+    // Open the command for reading
+    cmd += " 2>&1"; // hide errors
+    FILE* pipe = popen(cmd.c_str(), "r");
+    if (!pipe){
+        printf("Warning: Unable to execute cmd : %s\n", cmd.c_str());
+        return "";
+    }
+
+    char buffer[512];
+    std::string result;
+    while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
+        result += buffer;
+    }
+
+    // Grab exit code
+    int exitCode = pclose(pipe);
+
+    // Trim the newline character from the result
+    if (!result.empty() && result.back() == '\n') {
+        result.pop_back();
+    }
+
+    if(exitCode==0){
+        return result;
+    }
+
+    printf("System command failed: %s\n", result.c_str());
+    return "";
+}
+std::string liveCodeUtils::macGetSysRoot() {
+    // Sample: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+    return liveCodeUtils::macSysCall("xcrun --sdk macosx --show-sdk-path");
+}
+std::string liveCodeUtils::macGetCompilerPath() {
+    // Sample: /Library/Developer/CommandLineTools/usr/bin/clang++
+    std::string cmd = "xcrun --sdk macosx -f ";
+    cmd += OFXCPPSKETCH_DEFAULT_COMPILER;
+    return liveCodeUtils::macSysCall(cmd);
+}
+#endif
 
 
 File::File(string path) {

--- a/src/liveCodeUtils.h
+++ b/src/liveCodeUtils.h
@@ -11,6 +11,22 @@
 #include <set>
 #include <vector>
 
+#ifdef __clang__
+#define OFXCPPSKETCH_DEFAULT_COMPILER "clang++"
+#else
+#define OFXCPPSKETCH_DEFAULT_COMPILER "g++"
+#endif
+
+// Uncomment to use cout instead of printf
+//#define OFXCPPSKETCH_USE_COUT
+
+#ifdef OFXCPPSKETCH_USE_COUT // replace printf ?
+#include <iostream>
+#include <sstream>
+void coutPrintf(const char* format, ...);
+#define printf coutPrintf // override printf call by macro
+#endif
+
 namespace liveCodeUtils {
 	void init();
 	std::string execute(std::string cmd, int *outExitCode = nullptr);
@@ -23,6 +39,13 @@ namespace liveCodeUtils {
 
 	// this returns a list of paths to all .h files in the baseDir
 	std::vector<std::string> getAllHeaderFiles(std::string baseDir);
+
+	// OSX helpers for grabbing system SDK settings
+#ifdef __APPLE__
+	std::string macSysCall(std::string cmd);
+	std::string macGetSysRoot();
+	std::string macGetCompilerPath();
+#endif
 };
 
 

--- a/src/ofxCppSketch.h
+++ b/src/ofxCppSketch.h
@@ -133,8 +133,10 @@ protected:
 	
 	bool isIncludePath(string path) {
 		int incPos = path.rfind("/include");
-		return (incPos==path.size()-8) ||
-		(incPos==path.size()-9 && path[path.size()-1]=='/');
+		int incPosSrc = path.rfind("/src"); // For when source folder has includes too
+		return
+			((incPos==path.size()-8) || (incPos==path.size()-9 && path[path.size()-1]=='/')) ||
+			((incPosSrc==path.size()-4) || (incPosSrc==path.size()-5 && path[path.size()-1]=='/'));
 	}
 	
 	

--- a/src/ofxCppSketch.h
+++ b/src/ofxCppSketch.h
@@ -13,7 +13,27 @@ public:
 
 	ofxCppSketch(string className, string mainFilePath) : ofBaseApp() {
 		this->className = className;
-		srcDir = std::filesystem::path(mainFilePath).parent_path();
+		// Allow "weak" paths.
+		// Lets user provide "/of_v0.12.0/apps/cppSketch/src/ofAppConfig.cpp/../ofApp.php" as path
+		// With this code in ofAppConfig.cpp: `#define CPPSKETCH_APPFILE __FILE__ "/../ofApp.cpp"`
+		std::string resolvedPath = std::filesystem::weakly_canonical(mainFilePath).string();
+		srcDir = std::filesystem::path(resolvedPath).parent_path();
+		ofDirectory srcDirectory(srcDir);
+		if(!srcDirectory.exists()){
+			ofLogError("ofxCppSketch::ofxCppSketch()") << "Source directory `" << srcDir << "` doesn't exist !";
+		}
+
+		// Show debug setup info
+#ifdef DEBUG
+		std::string libsPath = getLibsPath();
+		std::string addonsPath = getAddonsPath();
+		ofDirectory libsDir(libsPath);
+		ofDirectory addonsDir(addonsPath);
+		ofLogNotice("ofxCppSketch::ofxCppSketch()")
+			<< " - New live sketch : " << className << " @ " << srcDir << (srcDirectory.exists()?" (ok)":" (error!)") << std::endl
+			<< " - Libs            : " << getLibsPath() << (libsDir.exists()?" (ok)":" (error!)") << std::endl
+			<< " - Addons          : " << getAddonsPath() << (addonsDir.exists()?" (ok)":" (error!)")  << std::endl;
+#endif
 	}
 	
 	void setup() override {
@@ -139,9 +159,14 @@ protected:
 		vector<string> addons;
 		std::string line;
 		while (std::getline(infile, line)) {
+			// Normally, addons can be disabled by commenting them `#`.
+			if(line.find('#')!=line.npos){
+				printf("Ignoring comment: %s", line.c_str());
+				continue;
+			}
 			if(line.size()>3 /*&& line!="ofxCppSketch"*/) { // check there's some text on the line
 				addons.push_back(line);
-				printf("%s\n", line.c_str());
+				printf("Found addon: %s", line.c_str());
 			}
 		}
 		return addons;

--- a/src/ofxCppSketch.h
+++ b/src/ofxCppSketch.h
@@ -191,8 +191,11 @@ protected:
 	}
 
 	void exit() override {
-		if(liveApp) liveApp->exit();
-		delete liveApp;
+		if(liveApp){
+			liveApp->exit();
+			delete liveApp;
+			liveApp = nullptr;
+		}
 	}
 	
 	void keyPressed(int key) override {

--- a/src/ofxCppSketch.h
+++ b/src/ofxCppSketch.h
@@ -43,9 +43,16 @@ public:
 			getSoundStream()->outCallback = nullptr;
 		};
 		reloader.reloaded = [this](ofBaseApp *app) {
-			
-			liveApp = app;
-			liveApp->setup();
+			if(app!=nullptr){
+				// Unload previous one
+				if(liveApp){
+					liveApp->exit();
+					delete liveApp;
+				}
+				// Replace
+				liveApp = app;
+				liveApp->setup();
+			}
 			getSoundStream()->audioMutex.unlock();
 		};
 		
@@ -181,6 +188,11 @@ protected:
 	
 	void draw() override {
 		if(liveApp) liveApp->draw();
+	}
+
+	void exit() override {
+		if(liveApp) liveApp->exit();
+		delete liveApp;
 	}
 	
 	void keyPressed(int key) override {


### PR DESCRIPTION
Hello @mazbox ,

I have added a few features and fixes to your addon :

- Add support for `clang++` (_and thus qt-creator support, also facilitates linux support_)
- Auto-detect STD version (fixes of_v0.12.1 and of_v0.12.0 with custom version).
- Ability to set/force custom apple_sdk, compiler, extraflags, std_version (see example)
- Add (opt-in) macro to use cout instead of printf. (I see printf only when the ofApp quits)
- Allow `/path/to/file.cpp/../otherFile.cpp` in setup's file_path for ease of use.
- Improve printf messages.
- Add setup warnings.
- Allow comments for parsing `addons.make` (improves addon compatibility/detection).
- Addon libs includes : Also detect "src" for includes and ignore some common files & folders.
- Properly call/forward `ofApp::exit()`.
- Fix memory leaks on ofApp.

No breaking changes, all defaults remain the same.

Are you interested in merging this ?